### PR TITLE
Added some things and fixing create_table.sql

### DIFF
--- a/create_table.sql
+++ b/create_table.sql
@@ -11,8 +11,9 @@ CREATE TABLE public.ethtxs
     txhash citext COLLATE pg_catalog."default",
     value numeric,
     contract_to citext COLLATE pg_catalog."default",
-    contract_value citext COLLATE pg_catalog."default"
-)
+    contract_value citext COLLATE pg_catalog."default",
+    status boolean
+);
 
 CREATE TABLE public.aval
 (

--- a/ethstorage.service
+++ b/ethstorage.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=EthereumTransactionStorage
-After=syslog.target
-After=network.target
-After=postgresql.service
+After=syslog.target network.target postgresql.service
 
 [Service]
 ExecStart=/usr/bin/python3.6 you/path/to/script/ethsync.py <yourDB>
@@ -11,4 +9,4 @@ RestartSec=90
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/ethsync.py
+++ b/ethsync.py
@@ -30,18 +30,18 @@ logger = logging.getLogger("EthIndexerLog")
 logger.setLevel(logging.INFO)
 
 # File logger
-#lfh = logging.FileHandler("/var/log/ethindexer.log")
-#formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-#lfh.setFormatter(formatter)
-#logger.addHandler(lfh)
+lfh = logging.FileHandler("/var/log/ethindexer.log")
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+lfh.setFormatter(formatter)
+logger.addHandler(lfh)
 
 # Systemd logger, if we want to user journalctl logs
 # Install systemd-python and 
 # decomment "#from systemd.journal import JournalHandler" up
-ljc = JournalHandler()
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-ljc.setFormatter(formatter)
-logger.addHandler(ljc)
+#ljc = JournalHandler()
+#formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+#ljc.setFormatter(formatter)
+#logger.addHandler(ljc)
 
 try:
     conn = psycopg2.connect("dbname=" + dbname)

--- a/ethsync.py
+++ b/ethsync.py
@@ -10,6 +10,7 @@ import psycopg2
 import time
 import sys
 import logging
+#from systemd.journal import JournalHandler
 
 # Get postgre database name
 if len(sys.argv) < 2:
@@ -27,10 +28,20 @@ web3 = Web3(Web3.IPCProvider("/home/parity/.local/share/openethereum/jsonrpc.ipc
 # Start logger
 logger = logging.getLogger("EthIndexerLog")
 logger.setLevel(logging.INFO)
-lfh = logging.FileHandler("/var/log/ethindexer.log")
+
+# File logger
+#lfh = logging.FileHandler("/var/log/ethindexer.log")
+#formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+#lfh.setFormatter(formatter)
+#logger.addHandler(lfh)
+
+# Systemd logger, if we want to user journalctl logs
+# Install systemd-python and 
+# decomment "#from systemd.journal import JournalHandler" up
+ljc = JournalHandler()
 formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-lfh.setFormatter(formatter)
-logger.addHandler(lfh)
+ljc.setFormatter(formatter)
+logger.addHandler(ljc)
 
 try:
     conn = psycopg2.connect("dbname=" + dbname)
@@ -45,11 +56,23 @@ cur.execute('DELETE FROM public.ethtxs WHERE block = (SELECT Max(block) from pub
 cur.close()
 conn.close()
 
+# Wait for the node to be in sync before indexing
+logger.info("Waiting Ethereum node to be in sync...")
+
+while web3.eth.syncing != False:
+    # Change with the time, in second, do you want to wait
+    # before cheking again, default is 5 minutes
+    time.sleep(300)
+
+logger.info("Ethereum node is synced!")
+
 # Adds all transactions from Ethereum block
 def insertion(blockid, tr):
     time = web3.eth.getBlock(blockid)['timestamp']
     for x in range(0, tr):
         trans = web3.eth.getTransactionByBlock(blockid, x)
+        # Save also transaction status, should be null if pre byzantium blocks
+        status = bool(web3.eth.get_transaction_receipt(trans['hash']).status)
         txhash = trans['hash']
         value = trans['value']
         inputinfo = trans['input']
@@ -73,8 +96,8 @@ def insertion(blockid, tr):
             contract_to = ''
             contract_value = ''
         cur.execute(
-            'INSERT INTO public.ethtxs(time, txfrom, txto, value, gas, gasprice, block, txhash, contract_to, contract_value) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)',
-            (time, fr, to, value, gas, gasprice, blockid, txhash, contract_to, contract_value))
+            'INSERT INTO public.ethtxs(time, txfrom, txto, value, gas, gasprice, block, txhash, contract_to, contract_value, status) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)',
+            (time, fr, to, value, gas, gasprice, blockid, txhash, contract_to, contract_value, status))
 
 # Fetch all of new (not in index) Ethereum blocks and add transactions to index
 while True:


### PR DESCRIPTION
create_table.sql is not working
```
CREATE EXTENSION
psql:/opt/ETH-transactions-storage/create_table.sql:23: ERROR:  syntax error at or near "CREATE"
LINE 15: CREATE TABLE public.aval
         ^
psql:/opt/ETH-transactions-storage/create_table.sql:28: ERROR:  relation "public.ethtxs" does not exist
psql:/opt/ETH-transactions-storage/create_table.sql:33: ERROR:  relation "public.ethtxs" does not exist
psql:/opt/ETH-transactions-storage/create_table.sql:38: ERROR:  relation "public.ethtxs" does not exist
psql:/opt/ETH-transactions-storage/create_table.sql:43: ERROR:  relation "public.ethtxs" does not exist
psql:/opt/ETH-transactions-storage/create_table.sql:48: ERROR:  relation "public.ethtxs" does not exist
LINE 4:     FROM public.ethtxs;
                 ^
psql:/opt/ETH-transactions-storage/create_table.sql:50: ERROR:  relation "public.aval" does not exist
LINE 1: INSERT INTO public.aval(status) VALUES (1);
```

Added ; to the first create table, to work.

I've also added the possibility to save the status of a transaction, that should be null if a pre byzantium transaction

In the systemd service, After= requirements can be all on the same line

In ethsync.py I've added the possibility to save the status of a transaction, and wait for a node to be fully synced before starting to indexing. 
The service file for systemd can have a requirement of a sysetmd service for geth or other ethereum node to be up and runnig before strarting (so connecting to it) the indexer.